### PR TITLE
 Ensure license file is included in built wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Otherwise, this is not there by default.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>