### PR TITLE
Use text_unidecode rather than unidecode

### DIFF
--- a/normality/transliteration.py
+++ b/normality/transliteration.py
@@ -32,18 +32,27 @@ try:
 
 except ImportError:
     try:
-        # try to use unidecode (all Python, hence a bit slower)
-        from unidecode import unidecode
+        # try to use text_unidecode or unidecode (all Python, hence a bit slower)
+        try:
+            from text_unidecode import unidecode
 
-        def _latinize_internal(text, ascii=False):
-            # weirdly, schwa becomes an @ by default in unidecode
-            text = text.replace(u'ə', 'a')
-            return six.text_type(unidecode(text))
+            def _latinize_internal(text, ascii=False):
+                # weirdly, schwa becomes an @ by default in text_unidecode
+                text = text.replace(u'ə', 'a')
+                text = text.replace(u'Ə', 'A')
+                return six.text_type(unidecode(text))
+        except ImportError:
+            from unidecode import unidecode
+
+            def _latinize_internal(text, ascii=False):
+                # weirdly, schwa becomes an @ by default in unidecode
+                text = text.replace(u'ə', 'a')
+                return six.text_type(unidecode(text))
 
     except ImportError:
 
         def _latinize_internal(text, ascii=False):
-            warn("No transliteration library is available. Install 'pyicu' or 'unidecode'.", UnicodeWarning)  # noqa
+            warn("No transliteration library is available. Install 'pyicu' or 'text_unidecode' or 'unidecode'.", UnicodeWarning)  # noqa
             return text
 
 

--- a/test/test_normality.py
+++ b/test/test_normality.py
@@ -25,6 +25,10 @@ class NormalityTest(unittest.TestCase):
         self.assertEqual(u'порошенко петро олексіиович', normalize(text))
 
     def test_ahmad(self):
+        text = u'əhməd'
+        self.assertEqual('ahmad', ascii_text(text))
+
+    def test_AHMAD(self):
         text = u'FUAD ALIYEV ƏHMƏD OĞLU'
         self.assertEqual('FUAD ALIYEV AHMAD OGLU', ascii_text(text))
 


### PR DESCRIPTION
 * To support https://github.com/alephdata/fingerprints/issues/4 and
   avoid using a GPL-licensed library in this MIT-licensed library, we now try to import text_unidecode or unidecode otherwise.
 * Add test for upper-case "schwa"

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>