### PR TITLE
Correct conversion of float to string

### DIFF
--- a/normality/stringify.py
+++ b/normality/stringify.py
@@ -30,7 +30,9 @@ def stringify(
         return _clean_empty(value)
     if isinstance(value, (date, datetime)):
         return value.isoformat()
-    elif isinstance(value, (float, Decimal)):
+    elif isinstance(value, float):
+        return str(value)
+    elif isinstance(value, Decimal):
         return Decimal(value).to_eng_string()
     elif isinstance(value, bytes):
         if encoding is None:


### PR DESCRIPTION
Hi,
The difference in `float` and `Decimal` floating point representations may lead to discrepancies when converting from one type to another.
Here is an excerpt from https://docs.python.org/3/library/decimal.html#module-decimal:
> If value is a [float](https://docs.python.org/3/library/functions.html#float), the binary floating-point value is losslessly converted to its exact decimal equivalent. This conversion can often require 53 or more digits of precision. For example, Decimal(float('1.1')) converts to Decimal('1.100000000000000088817841970012523233890533447265625').

Therefore it is best to directly convert float type to string.